### PR TITLE
Ord for entry kind, small api improvements

### DIFF
--- a/src/v1/parser.rs
+++ b/src/v1/parser.rs
@@ -123,7 +123,10 @@ quick_error! {
     }
 }
 
-/// Represents a type of the entry inside a signature file
+/// Represents a type of the entry inside a signature file.
+///
+/// Entry kinds are ordered in a way they appear in a signature file.
+/// Thus `File("/b") < Dir("/a")`.
 #[derive(Debug, PartialEq, Eq)]
 pub enum EntryKind<P: AsRef<Path>> {
     /// A directory
@@ -141,7 +144,7 @@ impl<P: AsRef<Path>> EntryKind<P> {
         }
     }
 
-    /// Converts to EntryKind<&Path>
+    /// Converts to `EntryKind<&Path>`
     pub fn as_ref(&self) -> EntryKind<&Path> {
         use self::EntryKind::*;
         match *self {
@@ -150,7 +153,7 @@ impl<P: AsRef<Path>> EntryKind<P> {
         }
     }
 
-    /// Clones path and returns EntryKind<PathBuf>
+    /// Clones path and returns `EntryKind<PathBuf>`
     pub fn cloned(&self) -> EntryKind<PathBuf> {
         use self::EntryKind::*;
         match *self {
@@ -177,6 +180,8 @@ impl<P> Ord for EntryKind<P>
         use std::cmp::Ordering::*;
         use self::EntryKind::*;
 
+        // we cannot just compare paths since directories and files are placed
+        // differently in a signature file
         match *self {
             Dir(ref path) => {
                 match *other {

--- a/src/v1/parser.rs
+++ b/src/v1/parser.rs
@@ -321,7 +321,7 @@ impl Entry {
     }
 
     /// Get path of the entry
-    pub fn get_path(&self) -> &Path {
+    pub fn path(&self) -> &Path {
         match *self {
             Entry::Dir(ref path) |
             Entry::File{ref path, ..} |
@@ -332,11 +332,11 @@ impl Entry {
     /// Returns kind of the entry. Can be passed into
     /// [`EntryIterator::advance`](struct.EntryIterator.html#method.advance)
     /// method
-    pub fn kind(&self) -> EntryKind<PathBuf> {
+    pub fn kind(&self) -> EntryKind<&Path> {
         match *self {
-            Entry::Dir(ref path) => EntryKind::Dir(path.clone()),
+            Entry::Dir(ref path) => EntryKind::Dir(path.as_ref()),
             Entry::File{ref path, ..} |
-            Entry::Link(ref path, _) => EntryKind::File(path.clone()),
+            Entry::Link(ref path, _) => EntryKind::File(path.as_ref()),
         }
     }
 }
@@ -495,7 +495,7 @@ impl<'a, R: BufRead> EntryIterator<'a, R> {
                         },
                         Ordering::Equal => {},
                     }
-                    let current_path = entry.get_path().to_path_buf();
+                    let current_path = entry.path().to_path_buf();
                     match current_path.as_path().cmp(path) {
                         Ordering::Less => {
                             self.current_row.clear();


### PR DESCRIPTION
There were some api changes:
- `Entry::get_path` was renamed to `Entry::path`
- `Entry::kind` now returns `EntryKind<&Path>` (don't know why it returned `EntryKind<PathBuf>`)

But there was not release with the above api so I think we can change it.