### PR TITLE
support target armv7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ sha2 = "0.7.0"
 blake2 = "0.7.0"
 digest-writer = "0.3.1"
 generic-array = "0.9.0"
-openat = "0.1.12"
+openat = "0.1.13"
 itertools = "0.7.3"
 
 num_cpus = { version="1.7.0", optional=true }


### PR DESCRIPTION
minor change : only increased version number of 'openat' crate to get 'dir-signature' compiled on arm target